### PR TITLE
implement proper parsing of float CPU values

### DIFF
--- a/lib/leader.js
+++ b/lib/leader.js
@@ -112,7 +112,7 @@ module.exports = function(core){
 
                     // find hosts with available resources
                     var resources = {
-                        cpus: _.parseInt(container.cpus),
+                        cpus: parseFloat(container.cpus),
                         memory: _.parseInt(container.memory)
                     }
 
@@ -166,7 +166,7 @@ module.exports = function(core){
                             var available_memory = host.memory / (1024 * 1024);
                             _.each(core.hosts.get_containers(host.id), function(container){
                                 available_memory -= _.parseInt(container.memory) + overhead;
-                                available_cpus -= _.parseInt(container.cpus);
+                                available_cpus -= parseFloat(container.cpus);
                             });
 
                             available_memory -= overhead;


### PR DESCRIPTION
fixes bug where CPU value would be rounded to nearest int, causing overscheduling