### PR TITLE
disregard metadata tag when attempting to place container

### DIFF
--- a/lib/leader.js
+++ b/lib/leader.js
@@ -147,6 +147,8 @@ module.exports = function(core){
                     // filter hosts by tag
                     by_tag: function(filtered_hosts, tags){
                         delete tags.constraints;
+                        delete tags.metadata;
+
                         return _.filter(filtered_hosts, function(host){
                             var matched = 0;
                             _.each(tags, function(value, tag){


### PR DESCRIPTION
implements ability to specify metadata about an application in the form of tags, without having those tags affect placement during the deployment process.

This addresses growbrosops/containership.plugin.navigator#16